### PR TITLE
Update setup.py, add pkg-exclude mask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/chemaaa/homepluscontrol",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["test","test.*"]),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
otherwise build will fail, because a package called "test" will be installed at top level:

```
>>> Emerging (1 of 1) dev-python/homepluscontrol-0.0.5::HomeAssistantRepository
>>> Failed to emerge dev-python/homepluscontrol-0.0.5, Log file:
>>>  '/var/tmp/portage/dev-python/homepluscontrol-0.0.5/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.71, 0.61, 0.58
 * Package:    dev-python/homepluscontrol-0.0.5
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   chemaaar@gmail.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking homepluscontrol-0.0.5.tar.gz to /var/tmp/portage/dev-python/homepluscontrol-0.0.5/work
>>> Source unpacked in /var/tmp/portage/dev-python/homepluscontrol-0.0.5/work
>>> Preparing source in /var/tmp/portage/dev-python/homepluscontrol-0.0.5/work/homepluscontrol-0.0.5 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/homepluscontrol-0.0.5/work/homepluscontrol-0.0.5 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/homepluscontrol-0.0.5/work/homepluscontrol-0.0.5 ...
 * python3_8: running distutils-r1_run_phase distutils-r1_python_compile
python3.8 setup.py build -j 10
running build
running build_py
...
running install_egg_info
running egg_info
writing homepluscontrol.egg-info/PKG-INFO
writing dependency_links to homepluscontrol.egg-info/dependency_links.txt
writing requirements to homepluscontrol.egg-info/requires.txt
writing top-level names to homepluscontrol.egg-info/top_level.txt
reading manifest file 'homepluscontrol.egg-info/SOURCES.txt'
writing manifest file 'homepluscontrol.egg-info/SOURCES.txt'
Copying homepluscontrol.egg-info to /var/tmp/portage/dev-python/homepluscontrol-0.0.5/image/_python3.8/usr/lib/python3.8/site-packages/homepluscontrol-0.0.5-py3.8.egg-info
running install_scripts
 * ERROR: dev-python/homepluscontrol-0.0.5::HomeAssistantRepository failed (install phase):
 *   Package installs 'test' package which is forbidden and likely a bug in the build system.
```