### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
     author="chemaaa",
     author_email="chemaaar@gmail.com",
     description="Python-based API to interact with the Legrand Home + Control interface",
+    license="GPLv3",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/chemaaa/homepluscontrol",


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.