### PR TITLE
Remove filtering of modules on the API's side. 

### DIFF
--- a/homepluscontrol/homeplusapi.py
+++ b/homepluscontrol/homeplusapi.py
@@ -4,8 +4,6 @@ import logging
 import time
 
 from .authentication import AbstractHomePlusOAuth2Async
-from .homeplusautomation import HomePlusAutomation
-from .homeplusinteractivemodule import HomePlusInteractiveModule
 from .homeplusplant import HomePlusPlant, PLANT_TOPOLOGY_BASE_URL
 
 CONF_PLANT_UPDATE_INTERVAL = "plant_update_interval"
@@ -268,19 +266,15 @@ class HomePlusControlAPI(AbstractHomePlusOAuth2Async):
             dict: Dictionary of modules across all of the plants.
         """
         for plant in self._plants.values():
-            # Loop through the modules in the plant and we only keep the ones that are "interactive"
-            # and can be represented by a switch, i.e. power outlets, micromodules
-            # and light switches. All other modules are discarded/ignored.
             current_module_ids = set()
             for module in list(plant.modules.values()):
-                if isinstance(module, HomePlusInteractiveModule, HomePlusAutomation):
-                    current_module_ids.add(module.id)
-                    if module.id not in self._modules:
-                        self.logger.debug(
-                            "Registering Home+ Control module in internal map: %s.",
-                            str(module),
-                        )
-                        self._modules[module.id] = module
+                current_module_ids.add(module.id)
+                if module.id not in self._modules:
+                    self.logger.debug(
+                        "Registering Home+ Control module in internal map: %s.",
+                        str(module),
+                    )
+                    self._modules[module.id] = module
 
             # Discard modules that may have disappeared from the topology
             modules_to_pop = set(self._modules) - current_module_ids

--- a/homepluscontrol/homeplusapi.py
+++ b/homepluscontrol/homeplusapi.py
@@ -4,8 +4,9 @@ import logging
 import time
 
 from .authentication import AbstractHomePlusOAuth2Async
-from .homeplusplant import HomePlusPlant, PLANT_TOPOLOGY_BASE_URL
+from .homeplusautomation import HomePlusAutomation
 from .homeplusinteractivemodule import HomePlusInteractiveModule
+from .homeplusplant import HomePlusPlant, PLANT_TOPOLOGY_BASE_URL
 
 CONF_PLANT_UPDATE_INTERVAL = "plant_update_interval"
 CONF_PLANT_TOPOLOGY_UPDATE_INTERVAL = "plant_topology_update_interval"
@@ -272,7 +273,7 @@ class HomePlusControlAPI(AbstractHomePlusOAuth2Async):
             # and light switches. All other modules are discarded/ignored.
             current_module_ids = set()
             for module in list(plant.modules.values()):
-                if isinstance(module, HomePlusInteractiveModule):
+                if isinstance(module, HomePlusInteractiveModule, HomePlusAutomation):
                     current_module_ids.add(module.id)
                     if module.id not in self._modules:
                         self.logger.debug(


### PR DESCRIPTION
Filtering modules should be done per platform by the integration on HA's side. 
This will be done in `switch.py` and `cover.py` by something like this (in this case for covers):

```py
new_entities = [
        HomeControlCoverEntity(coordinator, uid)
        for uid in new_unique_ids
        if coordinator.data[uid].device == "automation"
    ]
```

Can you confirm the `coordinator.data[uid].device` for switches ?