### PR TITLE
Fix error caused by modules with no "name" attribute

### DIFF
--- a/homepluscontrol/homeplusplant.py
+++ b/homepluscontrol/homeplusplant.py
@@ -226,7 +226,7 @@ class HomePlusPlant:
             plant=self,
             id=input_module["id"],
             device=module_product_type,
-            name=input_module["name"],
+            name=input_module.get("name", "Unknown"),
             hw_type=input_module["type"],
             type=input_module.get("appliance_type"),
             bridge=input_module.get("bridge"),


### PR DESCRIPTION
For some unknown reason, a module may not have a "name" property. Added a way to handle these rare cases by defaulting to "Unknown"